### PR TITLE
🎨 Palette: Input field polish & Tone System consistency

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Tone System Consistency & Input Polish]
+**Learning:** Shared UI components must use dynamic tokens (like spacingProvider) instead of hardcoded values to respect the app's 'Tone System' (Friendly vs Professional). Refactoring these to ConsumerStatefulWidget requires careful controller synchronization in didUpdateWidget.
+**Action:** Always check for spacingProvider usage in new or modified UI components.

--- a/lib/shared/widgets/common_text_input_field.dart
+++ b/lib/shared/widgets/common_text_input_field.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+import 'package:mudra_manager/core/providers/spacing_provider.dart';
 
-class CommonTextInputField extends StatefulWidget {
+class CommonTextInputField extends ConsumerStatefulWidget {
   final TextEditingController? controller;
   final String? labelText;
   final String? hintText;
@@ -21,73 +25,79 @@ class CommonTextInputField extends StatefulWidget {
   });
 
   @override
-  State<CommonTextInputField> createState() => _CommonTextInputFieldState();
+  ConsumerState<CommonTextInputField> createState() => _CommonTextInputFieldState();
 }
 
-class _CommonTextInputFieldState extends State<CommonTextInputField> {
+class _CommonTextInputFieldState extends ConsumerState<CommonTextInputField> {
   final FocusNode _focusNode = FocusNode();
   bool _isFocused = false;
+  late TextEditingController _effectiveController;
 
   @override
   void initState() {
     super.initState();
+    _effectiveController = widget.controller ?? TextEditingController();
     _focusNode.addListener(_onFocusChange);
+    _effectiveController.addListener(_onTextChanged);
+  }
+
+  @override
+  void didUpdateWidget(CommonTextInputField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.controller != oldWidget.controller) {
+      oldWidget.controller?.removeListener(_onTextChanged);
+      if (oldWidget.controller == null) _effectiveController.dispose();
+      _effectiveController = widget.controller ?? TextEditingController();
+      _effectiveController.addListener(_onTextChanged);
+    }
   }
 
   @override
   void dispose() {
     _focusNode.removeListener(_onFocusChange);
+    _effectiveController.removeListener(_onTextChanged);
+    if (widget.controller == null) _effectiveController.dispose();
     _focusNode.dispose();
     super.dispose();
   }
 
-  void _onFocusChange() {
-    setState(() {
-      _isFocused = _focusNode.hasFocus;
-    });
-  }
+  void _onFocusChange() => setState(() => _isFocused = _focusNode.hasFocus);
+  void _onTextChanged() => setState(() {});
 
   @override
   Widget build(BuildContext context) {
     final color = Theme.of(context).colorScheme;
+    final radius = BorderRadius.circular(ref.watch(spacingProvider).radiusSmall);
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8),
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 300),
         decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(16),
-          boxShadow: _isFocused
-              ? [
-                  BoxShadow(
-                    color: color.primary.withValues(alpha: 0.05),
-                    blurRadius: 4,
-                    offset: const Offset(0, 2),
-                  ),
-                ]
-              : [],
+          borderRadius: radius,
+          boxShadow: _isFocused ? [BoxShadow(color: color.primary.withValues(alpha: 0.05), blurRadius: 4, offset: const Offset(0, 2))] : [],
         ),
         child: TextFormField(
-          controller: widget.controller,
+          controller: _effectiveController,
           focusNode: _focusNode,
           decoration: InputDecoration(
             labelText: widget.labelText,
             hintText: widget.hintText,
-            prefixIcon: Icon(
-              widget.iconData,
-              color: _isFocused ? color.primary : color.onSurfaceVariant,
-            ),
-            border: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(16),
-            ),
-            focusedBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(16),
-              borderSide: BorderSide(color: color.primary, width: 2.0),
-            ),
-            enabledBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(16),
-              borderSide: BorderSide(color: color.outline, width: 1.0),
-            ),
+            prefixIcon: widget.iconData != null ? Icon(widget.iconData, color: _isFocused ? color.primary : color.onSurfaceVariant) : null,
+            suffixIcon: _effectiveController.text.isNotEmpty && _isFocused
+                ? IconButton(
+                    icon: const Icon(LucideIcons.circleX, size: 20),
+                    onPressed: () {
+                      HapticFeedback.mediumImpact();
+                      _effectiveController.clear();
+                      widget.onChanged?.call('');
+                    },
+                    tooltip: 'Clear',
+                  )
+                : null,
+            border: OutlineInputBorder(borderRadius: radius),
+            focusedBorder: OutlineInputBorder(borderRadius: radius, borderSide: BorderSide(color: color.primary, width: 2.0)),
+            enabledBorder: OutlineInputBorder(borderRadius: radius, borderSide: BorderSide(color: color.outline, width: 1.0)),
           ),
           textInputAction: TextInputAction.next,
           keyboardType: widget.inputType,


### PR DESCRIPTION
💡 What: Added a "Clear" button to `CommonTextInputField` and synced its border radius with the app's dynamic Tone System.
🎯 Why: Improves input efficiency by allowing one-tap clears and ensures the input field looks sharp in "Professional" mode and soft in "Friendly" mode.
♿ Accessibility: Added 'Clear' tooltip and haptic feedback to the new action.
🛠️ Engineering: Converted to `ConsumerStatefulWidget` with proper `didUpdateWidget` synchronization for `TextEditingController`.

---
*PR created automatically by Jules for task [17614000098981079990](https://jules.google.com/task/17614000098981079990) started by @aloketewary*