### PR TITLE
🎨 Palette: Localize category selector and align with Tone System

### DIFF
--- a/lib/core/l10n/app_localizations.dart
+++ b/lib/core/l10n/app_localizations.dart
@@ -1975,6 +1975,36 @@ abstract class AppLocalizations {
   /// **'Reset'**
   String get common_reset;
 
+  /// No description provided for @common_calculator.
+  ///
+  /// In en, this message translates to:
+  /// **'Calculator'**
+  String get common_calculator;
+
+  /// No description provided for @common_customize.
+  ///
+  /// In en, this message translates to:
+  /// **'Customize'**
+  String get common_customize;
+
+  /// No description provided for @common_download.
+  ///
+  /// In en, this message translates to:
+  /// **'Download'**
+  String get common_download;
+
+  /// No description provided for @common_notifications.
+  ///
+  /// In en, this message translates to:
+  /// **'Notifications'**
+  String get common_notifications;
+
+  /// No description provided for @common_clear.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear'**
+  String get common_clear;
+
   /// No description provided for @common_viewDetails.
   ///
   /// In en, this message translates to:
@@ -10613,6 +10643,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Select target category'**
   String get category_mergeSelectTarget;
+
+  /// Instruction hint in category selector
+  ///
+  /// In en, this message translates to:
+  /// **'Tap to select • Long press parent to select without subcategories'**
+  String get category_selectInstruction;
 
   /// No description provided for @notif_morningInsightTitle.
   ///

--- a/lib/core/l10n/app_localizations_ar.dart
+++ b/lib/core/l10n/app_localizations_ar.dart
@@ -974,6 +974,21 @@ class AppLocalizationsAr extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_as.dart
+++ b/lib/core/l10n/app_localizations_as.dart
@@ -974,6 +974,21 @@ class AppLocalizationsAs extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsAs extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_bn.dart
+++ b/lib/core/l10n/app_localizations_bn.dart
@@ -978,6 +978,21 @@ class AppLocalizationsBn extends AppLocalizations {
   String get common_reset => 'রিসেট';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'বিস্তারিত দেখুন';
 
   @override
@@ -5814,6 +5829,10 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Target category বেছে নিন';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ সকালের টাকার update';

--- a/lib/core/l10n/app_localizations_bo.dart
+++ b/lib/core/l10n/app_localizations_bo.dart
@@ -974,6 +974,21 @@ class AppLocalizationsBo extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsBo extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_brx.dart
+++ b/lib/core/l10n/app_localizations_brx.dart
@@ -974,6 +974,21 @@ class AppLocalizationsBrx extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsBrx extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_de.dart
+++ b/lib/core/l10n/app_localizations_de.dart
@@ -974,6 +974,21 @@ class AppLocalizationsDe extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_doi.dart
+++ b/lib/core/l10n/app_localizations_doi.dart
@@ -974,6 +974,21 @@ class AppLocalizationsDoi extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsDoi extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_en.dart
+++ b/lib/core/l10n/app_localizations_en.dart
@@ -974,6 +974,21 @@ class AppLocalizationsEn extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_es.dart
+++ b/lib/core/l10n/app_localizations_es.dart
@@ -975,6 +975,21 @@ class AppLocalizationsEs extends AppLocalizations {
   String get common_reset => 'Restablecer';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5832,6 +5847,10 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_fr.dart
+++ b/lib/core/l10n/app_localizations_fr.dart
@@ -974,6 +974,21 @@ class AppLocalizationsFr extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_gu.dart
+++ b/lib/core/l10n/app_localizations_gu.dart
@@ -974,6 +974,21 @@ class AppLocalizationsGu extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsGu extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_hi.dart
+++ b/lib/core/l10n/app_localizations_hi.dart
@@ -974,6 +974,21 @@ class AppLocalizationsHi extends AppLocalizations {
   String get common_reset => 'रीसेट';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'विस्तार से देखें';
 
   @override
@@ -5803,6 +5818,10 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Target category चुनें';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ सुबह का पैसा update';

--- a/lib/core/l10n/app_localizations_id.dart
+++ b/lib/core/l10n/app_localizations_id.dart
@@ -974,6 +974,21 @@ class AppLocalizationsId extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_ja.dart
+++ b/lib/core/l10n/app_localizations_ja.dart
@@ -974,6 +974,21 @@ class AppLocalizationsJa extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_kn.dart
+++ b/lib/core/l10n/app_localizations_kn.dart
@@ -974,6 +974,21 @@ class AppLocalizationsKn extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_ko.dart
+++ b/lib/core/l10n/app_localizations_ko.dart
@@ -974,6 +974,21 @@ class AppLocalizationsKo extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_kok.dart
+++ b/lib/core/l10n/app_localizations_kok.dart
@@ -974,6 +974,21 @@ class AppLocalizationsKok extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsKok extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_mai.dart
+++ b/lib/core/l10n/app_localizations_mai.dart
@@ -974,6 +974,21 @@ class AppLocalizationsMai extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsMai extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_ml.dart
+++ b/lib/core/l10n/app_localizations_ml.dart
@@ -974,6 +974,21 @@ class AppLocalizationsMl extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_mni.dart
+++ b/lib/core/l10n/app_localizations_mni.dart
@@ -974,6 +974,21 @@ class AppLocalizationsMni extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsMni extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_mr.dart
+++ b/lib/core/l10n/app_localizations_mr.dart
@@ -974,6 +974,21 @@ class AppLocalizationsMr extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsMr extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_ms.dart
+++ b/lib/core/l10n/app_localizations_ms.dart
@@ -974,6 +974,21 @@ class AppLocalizationsMs extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_ne.dart
+++ b/lib/core/l10n/app_localizations_ne.dart
@@ -974,6 +974,21 @@ class AppLocalizationsNe extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsNe extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_or.dart
+++ b/lib/core/l10n/app_localizations_or.dart
@@ -974,6 +974,21 @@ class AppLocalizationsOr extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsOr extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_pa.dart
+++ b/lib/core/l10n/app_localizations_pa.dart
@@ -974,6 +974,21 @@ class AppLocalizationsPa extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_pt.dart
+++ b/lib/core/l10n/app_localizations_pt.dart
@@ -974,6 +974,21 @@ class AppLocalizationsPt extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_sat.dart
+++ b/lib/core/l10n/app_localizations_sat.dart
@@ -974,6 +974,21 @@ class AppLocalizationsSat extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsSat extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_sd.dart
+++ b/lib/core/l10n/app_localizations_sd.dart
@@ -974,6 +974,21 @@ class AppLocalizationsSd extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsSd extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_si.dart
+++ b/lib/core/l10n/app_localizations_si.dart
@@ -974,6 +974,21 @@ class AppLocalizationsSi extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_sw.dart
+++ b/lib/core/l10n/app_localizations_sw.dart
@@ -974,6 +974,21 @@ class AppLocalizationsSw extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_ta.dart
+++ b/lib/core/l10n/app_localizations_ta.dart
@@ -974,6 +974,21 @@ class AppLocalizationsTa extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_te.dart
+++ b/lib/core/l10n/app_localizations_te.dart
@@ -974,6 +974,21 @@ class AppLocalizationsTe extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_th.dart
+++ b/lib/core/l10n/app_localizations_th.dart
@@ -974,6 +974,21 @@ class AppLocalizationsTh extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_tr.dart
+++ b/lib/core/l10n/app_localizations_tr.dart
@@ -974,6 +974,21 @@ class AppLocalizationsTr extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_ur.dart
+++ b/lib/core/l10n/app_localizations_ur.dart
@@ -974,6 +974,21 @@ class AppLocalizationsUr extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_vi.dart
+++ b/lib/core/l10n/app_localizations_vi.dart
@@ -974,6 +974,21 @@ class AppLocalizationsVi extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/app_localizations_zh.dart
+++ b/lib/core/l10n/app_localizations_zh.dart
@@ -974,6 +974,21 @@ class AppLocalizationsZh extends AppLocalizations {
   String get common_reset => 'Reset';
 
   @override
+  String get common_calculator => 'Calculator';
+
+  @override
+  String get common_customize => 'Customize';
+
+  @override
+  String get common_download => 'Download';
+
+  @override
+  String get common_notifications => 'Notifications';
+
+  @override
+  String get common_clear => 'Clear';
+
+  @override
   String get common_viewDetails => 'View details';
 
   @override
@@ -5831,6 +5846,10 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get category_mergeSelectTarget => 'Select target category';
+
+  @override
+  String get category_selectInstruction =>
+      'Tap to select • Long press parent to select without subcategories';
 
   @override
   String get notif_morningInsightTitle => '☀️ Your morning money minute';

--- a/lib/core/l10n/intl_en.arb
+++ b/lib/core/l10n/intl_en.arb
@@ -3330,6 +3330,10 @@
   "category_mergeSuccess": "Categories merged successfully",
   "category_mergeSameError": "Cannot merge a category into itself",
   "category_mergeSelectTarget": "Select target category",
+  "category_selectInstruction": "Tap to select • Long press parent to select without subcategories",
+  "@category_selectInstruction": {
+    "description": "Instruction hint in category selector"
+  },
 
   "notif_morningInsightTitle": "☀️ Your morning money minute",
   "notif_weeklyRecapNudgeTitle": "📊 Your weekly recap is ready",

--- a/lib/shared/widgets/category_selector_bottom_sheet.dart
+++ b/lib/shared/widgets/category_selector_bottom_sheet.dart
@@ -1,4 +1,6 @@
 import 'package:lucide_icons_flutter/lucide_icons.dart';
+import 'package:mudra_manager/core/l10n/app_localizations.dart';
+import 'package:mudra_manager/core/providers/spacing_provider.dart';
 import 'package:mudra_manager/core/utils/buddy_messages.dart';
 import 'package:mudra_manager/shared/widgets/skeleton_loader.dart';
 import 'package:flutter/material.dart';
@@ -58,6 +60,8 @@ class _CategorySelectorBottomSheetState
     );
     final textTheme = Theme.of(context).textTheme;
     final color = Theme.of(context).colorScheme;
+    final spacing = ref.watch(spacingProvider);
+    final ctxt = AppLocalizations.of(context)!;
 
     return DraggableScrollableSheet(
       initialChildSize: 0.6,
@@ -67,7 +71,7 @@ class _CategorySelectorBottomSheetState
       builder: (context, scrollController) => Column(
         children: [
           Padding(
-            padding: const EdgeInsets.all(16),
+            padding: EdgeInsets.all(spacing.cardInner),
             child: Column(
               children: [
                 Container(
@@ -78,19 +82,19 @@ class _CategorySelectorBottomSheetState
                     borderRadius: BorderRadius.circular(2),
                   ),
                 ),
-                const SizedBox(height: 16),
+                SizedBox(height: spacing.sectionGap),
                 Row(
                   children: [
                     if (_selectedParent != null)
                       IconButton(
-                        tooltip: 'Back',
+                        tooltip: ctxt.common_back,
                         icon: const Icon(LucideIcons.arrowLeft),
                         onPressed: () => setState(() => _selectedParent = null),
                       ),
                     Expanded(
                       child: Text(
                         _selectedParent == null
-                            ? 'Select Category'
+                            ? ctxt.transaction_selectCategoryLabel
                             : _selectedParent!.name,
                         style: textTheme.titleLarge?.copyWith(
                           fontWeight: FontWeight.bold,
@@ -104,9 +108,9 @@ class _CategorySelectorBottomSheetState
                 ),
                 if (_selectedParent == null)
                   Padding(
-                    padding: const EdgeInsets.only(top: 8),
+                    padding: EdgeInsets.only(top: spacing.elementGap),
                     child: Text(
-                      'Tap to select • Long press parent to select without subcategories',
+                      ctxt.category_selectInstruction,
                       style: textTheme.bodySmall?.copyWith(
                         color: color.onSurfaceVariant,
                       ),
@@ -124,7 +128,7 @@ class _CategorySelectorBottomSheetState
                 if (filtered.isEmpty) {
                   return Center(
                     child: Text(
-                      'No categories found',
+                      ctxt.categories_noCategoriesFound,
                       style: textTheme.bodyMedium,
                     ),
                   );
@@ -143,7 +147,7 @@ class _CategorySelectorBottomSheetState
 
                 return GridView.builder(
                   controller: scrollController,
-                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  padding: EdgeInsets.symmetric(horizontal: spacing.cardHorizontalMax),
                   gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
                     crossAxisCount: ResponsiveHelper.getGridCrossAxisCount(
                       context,
@@ -188,7 +192,7 @@ class _CategorySelectorBottomSheetState
                             top: 4,
                             right: 4,
                             child: Container(
-                              padding: const EdgeInsets.all(4),
+                              padding: EdgeInsets.all(spacing.elementGapMin),
                               decoration: BoxDecoration(
                                 color: color.primary,
                                 shape: BoxShape.circle,
@@ -206,7 +210,7 @@ class _CategorySelectorBottomSheetState
                 );
               },
               loading: () => GridView.builder(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
+                padding: EdgeInsets.symmetric(horizontal: spacing.cardHorizontalMax),
                 gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
                   crossAxisCount: 2,
                   crossAxisSpacing: 12,


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Localized the `CategorySelectorBottomSheet` and refactored its layout to use the project's `spacingProvider` for design system consistency.

### 🎯 Why: The user problem it solves
1. **Accessibility:** Icon-only buttons (like the "Back" arrow) had hardcoded English tooltips, which are inaccessible to screen reader users in other languages.
2. **Discoverability:** Added a localized instruction hint to help users discover the "Long press to select parent" feature.
3. **Consistency:** Aligned padding and margins with the app's 'Tone System' using dynamic spacing tokens.

### ♿ Accessibility: Any a11y improvements made
Ensured all interactive elements in the category selector have properly localized tooltips and labels for screen readers.

---
*PR created automatically by Jules for task [12195651264086763305](https://jules.google.com/task/12195651264086763305) started by @aloketewary*