### PR TITLE
🛡️ Sentinel: Encrypt RecurringBill PII and fix BillService query bug

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** Sensitive user-provided descriptions in Recurring Transactions and Goals were stored as plaintext, bypassing the encryption architecture used for regular Transactions.
 **Learning:** Encryption must be applied consistently across all models containing PII or financial notes. Relying on primary service classes for encryption is insufficient if secondary services or UI screens perform direct database writes (e.g., SMS approval flow, recurring processing).
 **Prevention:** Centralize encryption/decryption logic in model extensions and mandate their use in both retrieval (via `withDecryption()`) and persistence (via `encryptFields()`) layers across all feature modules.
+
+## 2025-05-28 - [Encrypted Query Failure & Double Encryption Risk]
+**Vulnerability:** Application logic failure (duplicate records) and potential data corruption when querying or saving encrypted fields.
+**Learning:** Standard database filters like `bodyContains()` fail on encrypted fields because the ciphertext does not contain the plaintext substrings. Additionally, calling `encryptFields()` multiple times on the same object (e.g., in nested service calls) leads to double-encryption, making data unrecoverable.
+**Prevention:** Use deterministic, non-encrypted indexed fields (like `smsHash`) for record lookups. Ensure that `encryptFields()` is called exactly once immediately before the final database write in a transaction, and decrypt the object if it needs to be reused.

--- a/lib/core/db/extensions/field_encryption_ext.dart
+++ b/lib/core/db/extensions/field_encryption_ext.dart
@@ -7,6 +7,7 @@ import 'package:mudra_manager/core/db/models/user_profile.dart';
 import 'package:mudra_manager/core/db/models/recurring_transaction.dart';
 import 'package:mudra_manager/core/db/models/goal.dart';
 import 'package:mudra_manager/core/db/models/pending_transaction.dart';
+import 'package:mudra_manager/core/db/models/recurring_bill.dart';
 
 /// Encrypt sensitive fields before writing to Isar.
 ///
@@ -47,6 +48,20 @@ extension TransactionEncryption on Transaction {
 
   void decryptFields() {
     if (!FieldEncryptionService.isReady) return;
+    description = FieldEncryptionService.decryptNullable(description);
+  }
+}
+
+extension RecurringBillEncryption on RecurringBill {
+  void encryptFields() {
+    if (!FieldEncryptionService.isReady) return;
+    name = FieldEncryptionService.encrypt(name);
+    description = FieldEncryptionService.encryptNullable(description);
+  }
+
+  void decryptFields() {
+    if (!FieldEncryptionService.isReady) return;
+    name = FieldEncryptionService.decrypt(name);
     description = FieldEncryptionService.decryptNullable(description);
   }
 }
@@ -115,6 +130,16 @@ extension UserProfileEncryption on UserProfile {
 /// Decrypt a list of SmsActivity after Isar read.
 extension SmsActivityListDecryption on Future<List<SmsActivity>> {
   Future<List<SmsActivity>> withDecryption() async {
+    final list = await this;
+    for (final item in list) {
+      item.decryptFields();
+    }
+    return list;
+  }
+}
+
+extension RecurringBillListDecryption on Future<List<RecurringBill>> {
+  Future<List<RecurringBill>> withDecryption() async {
     final list = await this;
     for (final item in list) {
       item.decryptFields();

--- a/lib/features/budget/data/bill_service.dart
+++ b/lib/features/budget/data/bill_service.dart
@@ -1,5 +1,6 @@
 import 'package:mudra_manager/core/utils/date_arithmetic.dart';
 import 'package:isar_community/isar.dart';
+import 'package:mudra_manager/core/db/extensions/field_encryption_ext.dart';
 import 'package:mudra_manager/core/db/models/pending_transaction.dart';
 import 'package:mudra_manager/core/db/models/recurring_bill.dart';
 
@@ -12,14 +13,16 @@ class BillService {
     final bills = await isar.recurringBills
         .filter()
         .isActiveEqualTo(true)
-        .findAll();
+        .findAll()
+        .withDecryption();
 
     for (final bill in bills) {
       if (bill.nextDueDate != null &&
           bill.nextDueDate!.isBefore(today.add(const Duration(days: 1)))) {
+        final hash = 'bill_${bill.id}_${bill.nextDueDate!.millisecondsSinceEpoch}';
         final existing = await isar.pendingTransactions
             .filter()
-            .bodyContains(bill.name)
+            .smsHashEqualTo(hash)
             .findFirst();
 
         if (existing == null) {
@@ -33,9 +36,9 @@ class BillService {
             ..isIncome = false
             ..category = bill.category.value?.name
             ..account = bill.account.value?.name
-            ..smsHash =
-                'bill_${bill.id}_${bill.nextDueDate!.millisecondsSinceEpoch}';
+            ..smsHash = hash;
 
+          pending.encryptFields();
           await isar.writeTxn(() async {
             await isar.pendingTransactions.put(pending);
           });
@@ -63,10 +66,12 @@ class BillService {
         break;
     }
 
+    bill.encryptFields();
     await isar.writeTxn(() async {
       bill.nextDueDate = nextDate;
       await isar.recurringBills.put(bill);
     });
+    bill.decryptFields();
   }
 
   static Future<void> markBillAsPaid(int billId) async {
@@ -75,10 +80,8 @@ class BillService {
 
     final bill = await isar.recurringBills.get(billId);
     if (bill != null) {
-      await isar.writeTxn(() async {
-        bill.lastPaidDate = DateTime.now();
-        await isar.recurringBills.put(bill);
-      });
+      bill.decryptFields();
+      bill.lastPaidDate = DateTime.now();
 
       await _updateNextDueDate(isar, bill);
     }

--- a/test/core/db/field_encryption_ext_test.dart
+++ b/test/core/db/field_encryption_ext_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mudra_manager/core/db/extensions/field_encryption_ext.dart';
 import 'package:mudra_manager/core/db/field_encryption_service.dart';
+import 'package:mudra_manager/core/db/models/recurring_bill.dart';
 import 'package:mudra_manager/core/db/models/sms_activity.dart';
 import 'package:mudra_manager/core/db/models/transaction.dart';
 
@@ -86,6 +87,50 @@ void main() {
 
       txn.encryptFields();
       expect(txn.description, isNull);
+    });
+  });
+
+  group('RecurringBill encryption (passthrough)', () {
+    test('encryptFields is no-op when not ready', () {
+      final bill = RecurringBill()
+        ..name = 'Rent'
+        ..description = 'Monthly apartment rent'
+        ..amount = 15000
+        ..dueDate = DateTime.now()
+        ..frequency = BillFrequency.monthly
+        ..isActive = true;
+
+      bill.encryptFields();
+
+      expect(bill.name, equals('Rent'));
+      expect(bill.description, equals('Monthly apartment rent'));
+    });
+
+    test('decryptFields is no-op when not ready', () {
+      final bill = RecurringBill()
+        ..name = 'ENC:fakeiv:fakename'
+        ..description = 'ENC:fakeiv:fakedesc'
+        ..amount = 15000
+        ..dueDate = DateTime.now()
+        ..frequency = BillFrequency.monthly
+        ..isActive = true;
+
+      bill.decryptFields();
+
+      expect(bill.name, equals('ENC:fakeiv:fakename'));
+      expect(bill.description, equals('ENC:fakeiv:fakedesc'));
+    });
+
+    test('encryptFields handles null description', () {
+      final bill = RecurringBill()
+        ..name = 'Rent'
+        ..amount = 15000
+        ..dueDate = DateTime.now()
+        ..frequency = BillFrequency.monthly
+        ..isActive = true;
+
+      bill.encryptFields();
+      expect(bill.description, isNull);
     });
   });
 


### PR DESCRIPTION
This PR addresses a security gap where `RecurringBill` data (names and descriptions) were stored in plaintext. It also fixes a functional bug in `BillService` introduced by the encryption of `PendingTransaction` bodies, where the service could no longer detect existing pending transactions.

Key changes:
1.  **Field-Level Encryption:** Added encryption/decryption extensions for the `RecurringBill` model.
2.  **Query Fix:** Refactored `BillService.createPendingTransactionsForDueBills` to use the deterministic `smsHash` index for checking existing transactions instead of a string-matching filter on the encrypted `body`.
3.  **Secure Persistence:** Updated `BillService` methods to ensure data is correctly decrypted before modification and encrypted before database writes, following the "fetch-decrypt-modify-encrypt-put" pattern to prevent double-encryption.
4.  **Verification:** Added unit tests to ensure the encryption extensions behave correctly (passthrough when service not ready) and ran analysis to confirm code quality.

---
*PR created automatically by Jules for task [18237212758483880151](https://jules.google.com/task/18237212758483880151) started by @aloketewary*