### PR TITLE
🛡️ Sentinel: [MEDIUM] Encrypt Goal and Budget names to protect PII

### DIFF
--- a/lib/core/db/extensions/field_encryption_ext.dart
+++ b/lib/core/db/extensions/field_encryption_ext.dart
@@ -8,6 +8,7 @@ import 'package:mudra_manager/core/db/models/user_profile.dart';
 import 'package:mudra_manager/core/db/models/recurring_transaction.dart';
 import 'package:mudra_manager/core/db/models/recurring_bill.dart';
 import 'package:mudra_manager/core/db/models/trip.dart';
+import 'package:mudra_manager/core/db/models/budget.dart';
 import 'package:mudra_manager/core/db/models/goal.dart';
 import 'package:mudra_manager/core/db/models/pending_transaction.dart';
 
@@ -281,12 +282,47 @@ extension PendingTransactionListDecryption
 extension GoalEncryption on Goal {
   void encryptFields() {
     if (!FieldEncryptionService.isReady) return;
+    name = FieldEncryptionService.encrypt(name);
     description = FieldEncryptionService.encryptNullable(description);
   }
 
   void decryptFields() {
     if (!FieldEncryptionService.isReady) return;
+    name = FieldEncryptionService.decrypt(name);
     description = FieldEncryptionService.decryptNullable(description);
+  }
+}
+
+extension BudgetEncryption on Budget {
+  void encryptFields() {
+    if (!FieldEncryptionService.isReady) return;
+    name = FieldEncryptionService.encrypt(name);
+  }
+
+  void decryptFields() {
+    if (!FieldEncryptionService.isReady) return;
+    name = FieldEncryptionService.decrypt(name);
+  }
+}
+
+extension BudgetListDecryption on Future<List<Budget>> {
+  Future<List<Budget>> withDecryption() async {
+    final list = await this;
+    for (final item in list) {
+      item.decryptFields();
+    }
+    return list;
+  }
+}
+
+extension BudgetStreamDecryption on Stream<List<Budget>> {
+  Stream<List<Budget>> withDecryption() {
+    return map((list) {
+      for (final item in list) {
+        item.decryptFields();
+      }
+      return list;
+    });
   }
 }
 
@@ -382,6 +418,38 @@ extension UserProfileDecryption on Future<UserProfile?> {
     final profile = await this;
     profile?.decryptFields();
     return profile;
+  }
+}
+
+extension GoalDecryption on Future<Goal?> {
+  Future<Goal?> withDecryption() async {
+    final goal = await this;
+    goal?.decryptFields();
+    return goal;
+  }
+}
+
+extension BudgetDecryption on Future<Budget?> {
+  Future<Budget?> withDecryption() async {
+    final budget = await this;
+    budget?.decryptFields();
+    return budget;
+  }
+}
+
+extension RecurringBillDecryption on Future<RecurringBill?> {
+  Future<RecurringBill?> withDecryption() async {
+    final bill = await this;
+    bill?.decryptFields();
+    return bill;
+  }
+}
+
+extension RecurringTransactionDecryption on Future<RecurringTransaction?> {
+  Future<RecurringTransaction?> withDecryption() async {
+    final rt = await this;
+    rt?.decryptFields();
+    return rt;
   }
 }
 

--- a/lib/features/budget/data/budget_service_provider.dart
+++ b/lib/features/budget/data/budget_service_provider.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:isar_community/isar.dart';
 import 'package:mudra_manager/core/db/isar_service.dart';
 import 'package:mudra_manager/core/db/models/budget.dart';
+import 'package:mudra_manager/core/db/extensions/field_encryption_ext.dart';
 import 'package:mudra_manager/core/db/models/budget_category_allocation.dart';
 import 'package:mudra_manager/core/db/models/budget_type.dart';
 import 'package:mudra_manager/core/db/models/category.dart';
@@ -39,7 +40,8 @@ final budgetWithProgressProvider =
   final budgets = await isar.budgets
       .where()
       .isArchivedEqualTo(false)
-      .findAll();
+      .findAll()
+      .withDecryption();
 
   final List<(Budget, double, DateTime, DateTime)> result = [];
   final now = DateTime.now();
@@ -88,7 +90,8 @@ class BudgetService {
     yield* isar.budgets
         .where()
         .isArchivedEqualTo(false)
-        .watch(fireImmediately: true);
+        .watch(fireImmediately: true)
+        .withDecryption();
   }
 
   Future<double> calculateSpentAmount(
@@ -110,7 +113,8 @@ class BudgetService {
     final budgets = await isar.budgets
         .where()
         .isArchivedEqualTo(false)
-        .findAll();
+        .findAll()
+        .withDecryption();
 
     final now = DateTime.now();
 
@@ -257,6 +261,7 @@ class BudgetService {
   Future<void> save(Budget bud, {List<BudgetCategoryAllocation> newAllocations = const []}) async {
     final isar = await isarService.getInstance();
     final isNew = bud.id == Isar.autoIncrement;
+    bud.encryptFields();
     await isar.writeTxn(() async {
       await isar.budgets.put(bud);
       await bud.categories.save();
@@ -295,7 +300,7 @@ class BudgetService {
   /// Fetch a single budget by ID
   Future<Budget?> getBudget(int budgetId) async {
     final isar = await isarService.getInstance();
-    return await isar.budgets.get(budgetId);
+    return await isar.budgets.get(budgetId).withDecryption();
   }
 
   // Archiving
@@ -317,7 +322,8 @@ class BudgetService {
         .startDateLessThan(now)
         .and()
         .endDateGreaterThan(now)
-        .findAll();
+        .findAll()
+        .withDecryption();
     return budgets;
   }
 
@@ -337,7 +343,8 @@ class BudgetService {
         .filter()
         .isArchivedEqualTo(true)
         .sortByStartDateDesc()
-        .findAll();
+        .findAll()
+        .withDecryption();
 
     final results = <ArchivedBudgetSummary>[];
     for (final budget in budgets) {

--- a/lib/features/goal/data/goal_provider.dart
+++ b/lib/features/goal/data/goal_provider.dart
@@ -59,7 +59,7 @@ class GoalService {
     final isar = await isarService.getInstance();
     Goal? goal;
     await isar.writeTxn(() async {
-      goal = await isar.goals.get(goalId);
+      goal = await isar.goals.get(goalId).withDecryption();
       if (goal != null) {
         goal!.currentAmount += amount;
         goal!.contributions.add(GoalContribution.create(amount));


### PR DESCRIPTION
🛡️ Sentinel: Encrypt Goal and Budget names to protect sensitive user PII

This enhancement extends the application's field-level AES-256 encryption architecture to include the `name` fields of `Goal` and `Budget` models. These fields often contain sensitive personal or financial intent (e.g., "Pay off debt to John").

Key Improvements:
1. **Privacy Protection**: Goal and Budget names are no longer stored in plaintext in the Isar database.
2. **Deterministic Encryption Pattern**: Verified that these fields are not used for server-side or database-level sorting/filtering that would be broken by encryption.
3. **Double-Encryption Prevention**: Added `.withDecryption()` extensions for single-record futures to ensure objects are decrypted before modification and re-encryption.

Files Modified:
- `lib/core/db/extensions/field_encryption_ext.dart`: Added encryption logic and helper extensions.
- `lib/features/budget/data/budget_service_provider.dart`: Integrated encryption into the budget data layer.
- `lib/features/goal/data/goal_provider.dart`: Secured the contribution update pipeline.

---
*PR created automatically by Jules for task [5108878975533875881](https://jules.google.com/task/5108878975533875881) started by @aloketewary*